### PR TITLE
Remove extra blank line at the end of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,4 +14,3 @@
 - `alembic upgrade head` - Applies migrations to DB
 
 `docker exec -ti tightlock_postgres_1 psql -U tightlock -W tightlock` - Runs Postgres REPL inside DB container (useful for inspecting tables)
-


### PR DESCRIPTION
Getting familiar with git CLI and github workflow: removed an extra blank line at the end of file.