### PR TITLE
Add lib64 (the symlink file, not the folder) to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ eggs/
 .eggs/
 lib/
 lib64/
+lib64
 parts/
 sdist/
 var/


### PR DESCRIPTION
While setting up py venv, a "lib64" symlink has been created (which points to the folder `lib` already in .gitignore).