### PR TITLE
Implement graceful failure for DAG registeration

### DIFF
--- a/dags/destinations/fail.py
+++ b/dags/destinations/fail.py
@@ -1,0 +1,20 @@
+"""This destination is supposed to fail and be gracefully handled."""
+
+
+from typing import Any, Dict, Iterable, Sequence
+
+
+class Destination:
+  """Implements DestinationProto protocol."""
+
+  def __init__(self, config: Dict[str, Any]):
+    raise Exception("Thuo shan't instantiate me!!!")
+
+  def send_data(self, input_data: Iterable[Any]) -> None:
+    print(f"input_data: {input_data}")
+
+  def fields(self) -> Sequence[str]:
+    return ["foo", "bar", "qux", "zap"]
+
+  def schema(self) -> Dict[str, Any]:
+    return {"foo": "bar"}

--- a/tightlock_api/app/base_config.json
+++ b/tightlock_api/app/base_config.json
@@ -50,6 +50,18 @@
         "debug": true
       },
       "schedule": ""
+    },
+    {
+      "name": "intended_failure",
+      "source": {
+        "type": "local_file",
+        "external_connection": "",
+        "location": "ga4_app_sample_data.csvh"
+      },
+      "destination": {
+        "type": "FAIL"
+      },
+      "schedule": ""
     }
   ],
   "secrets": {}


### PR DESCRIPTION
These changes handle possible errors when a specific DAG is being instantiate; failure on a specific DAG won't prevent the other DAGs from being instantiated.
I'm currently printing a messages to log that an error has occurred, however I'm not entirely sure where that trace is supposed to be surfaced (tightlock_api logs or airflow_web logs).
Never the less, http://localhost:8080 (Airflow Web Server) shows that the other 2 DAGs are successfully created and I can trigger the activation and see the data flow as expected.