### PR TITLE
Postgres CHMOD Fix

### DIFF
--- a/postgres.Dockerfile
+++ b/postgres.Dockerfile
@@ -13,4 +13,4 @@
 # limitations under the License.
 
 FROM postgres:15
-COPY postgres_init.sh /docker-entrypoint-initdb.d/
+COPY --chmod=755 postgres_init.sh /docker-entrypoint-initdb.d/

--- a/run_tightlock.sh
+++ b/run_tightlock.sh
@@ -25,8 +25,11 @@
   esac
 done
 
-# Create env
+# create env
 bash ./create_env.sh $INTERACTIVE_FLAG $ENV_FLAG $PROVIDED_API_KEY
+
+# enable docker buildkit
+export DOCKER_BUILDKIT=1
 
 # define which docker-compose command to use based on the environment
 if [ $ENV_FLAG == "prod" ]; then
@@ -35,5 +38,5 @@ else
   COMPOSE_CMD='docker-compose'
 fi
 
-# Run containers
+# run containers
 $COMPOSE_CMD up --build -d


### PR DESCRIPTION
Previously you needed to manually chmod the "postgres_init.sh" file before executing "./run_tightlock.sh".
This PR enables Docker BuildKit and makes use of one of its capabilities to use chmod with the COPY function `COPY --chmod=755` which removes the need to do this manually and ensures everything starts up properly the first time.